### PR TITLE
Forces overwrite of all files instead of asking

### DIFF
--- a/lib/capistrano/tasks/middleman.rake
+++ b/lib/capistrano/tasks/middleman.rake
@@ -55,7 +55,7 @@ namespace :middleman do
       # umask = capture('umask')
       # debug "umask on remote system #{host} is #{umask}"
 
-      execute :unzip, tmp_file, '-d', release_path
+      execute :unzip, '-o', tmp_file, '-d', release_path
       execute :rm, '-f', tmp_file
     end
   end


### PR DESCRIPTION
I ran into an issue with this repo because I was getting the following output:

```
DEBUG [f69cb351]        replace /apps/subvisual.co/releases/20150520164457/404/index.html? [y]es, [n]o, [A]ll, [N]one, [r]ename:
```

Adding the `-o` option to the unzip command forces it to overwrite everything without asking, which is probably what we want here