### PR TITLE
When zipping a release for transfer, also include dotfiles like .htaccess

### DIFF
--- a/lib/capistrano/middleman/utils.rb
+++ b/lib/capistrano/middleman/utils.rb
@@ -30,7 +30,7 @@ module Capistrano
         file_permissions: 0664,
         directory_permissions: 2775
       )
-        list = Rake::FileList.new(File.join(source_directory, '**', '*'))
+        list = Rake::FileList.new(File.join(source_directory, '**', '{*,.*}'))
         list.exclude { |f| !File.file? f }
         exclude_patterns.each { |e| list.exclude e }
 


### PR DESCRIPTION
We often have a `.htaccess` file in our Middleman projects. We use them to add some rewrite rules for Apache ([background](https://makandracards.com/makandra/45814-middleman-use-pretty-urls-without-doubling-requests)).

Unfortunately capistrano-middleman did not include files starting with a dot character when zipping a release for transfer. This commit includes dotfiles.