### PR TITLE
Loosen version requirement for Rubyzip

### DIFF
--- a/capistrano-middleman.gemspec
+++ b/capistrano-middleman.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'middleman', '~> 4.0'
   spec.add_runtime_dependency 'capistrano', '~> 3.0'
-  spec.add_runtime_dependency 'rubyzip', '~>1.1.7'
+  spec.add_runtime_dependency 'rubyzip', '~> 1.1'
 end


### PR DESCRIPTION
This allows you to use a version that has a fix for this security vulnerability: https://github.com/rubyzip/rubyzip/issues/315

The vulnerability doesn't affect static sites, but GitHub's security alerting system doesn't know that.

Here's the changelog: https://github.com/rubyzip/rubyzip/blob/2f80da6289d8a407b37b0782b09aabfdd3420240/Changelog.md#121

Fixes fedux-org/capistrano-middleman#7.